### PR TITLE
Fix wrong path for models endpoint

### DIFF
--- a/rockauto.py
+++ b/rockauto.py
@@ -82,7 +82,7 @@ async def get_years( search_make: str, search_link: str ):
 
     return years_list
 
-@rockauto_api.get("/years/{search_vehicle}")
+@rockauto_api.get("/models/{search_vehicle}")
 async def get_models( search_make: str, search_year: str, search_link: str ):
     models_list = []
 

--- a/test_rockauto.py
+++ b/test_rockauto.py
@@ -7,6 +7,11 @@ def test_endpoints_exist():
     routes = [route.path for route in rockauto_api.routes]
     assert "/" in routes
     assert "/makes" in routes
+    assert "/years/{search_vehicle}" in routes
+    assert "/models/{search_vehicle}" in routes
+    assert "/engines/{search_vehicle}" in routes
+    assert "/categories/{search_vehicle}" in routes
+    assert "/sub_categories/{search_vehicle}" in routes
     assert "/parts/{search_vehicle}" in routes
     assert "/closeouts/{carcode}" in routes
     assert "/vehicle_info/{search_vehicle}" in routes


### PR DESCRIPTION
## Summary
- correct the `get_models` route path so it uses `/models/{search_vehicle}` instead of `/years/{search_vehicle}`
- extend endpoint tests to verify all API routes exist

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef53a7408832faf082bdcbaae7834