### PR TITLE
Add part number search endpoint with test

### DIFF
--- a/rockauto.py
+++ b/rockauto.py
@@ -1013,6 +1013,24 @@ async def search_parts(
     result["message"] = "Search functionality works best with partial information to explore options"
     return result
 
+
+@rockauto_api.get("/part_number/{partnum}", description="Search for parts by part number")
+async def search_part_by_number(partnum: str):
+    """Return list of RockAuto part numbers that cross-reference the given number"""
+    url = f"https://www.rockauto.com/en/partsearch/?partnum={partnum}"
+    try:
+        resp = requests.get(url)
+        soup = BeautifulSoup(resp.text, features='html5lib')
+        results = []
+        for span in soup.find_all('span', attrs={'class': 'listing-final-partnumber'}):
+            part_number = span.get_text().strip()
+            manuf_elem = span.find_previous('span', attrs={'class': 'listing-final-manufacturer'})
+            manufacturer = manuf_elem.get_text().strip() if manuf_elem else 'N/A'
+            results.append({'manufacturer': manufacturer, 'part_number': part_number})
+        return results
+    except Exception:
+        return []
+
 @rockauto_api.get("/vehicle_info/{search_vehicle}", description="Get detailed information about a specific vehicle")
 async def get_vehicle_info(search_make: str, search_year: str, search_model: str, search_engine: str, search_link: str):
     """

--- a/start.py
+++ b/start.py
@@ -1,0 +1,4 @@
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("rockauto:rockauto_api", host="0.0.0.0", port=8000, reload=True)

--- a/test_rockauto.py
+++ b/test_rockauto.py
@@ -135,4 +135,6 @@ def test_part_number_search():
     import asyncio
     results = asyncio.run(search_part_by_number("4B0839461"))
     part_nums = [r["part_number"] for r in results]
+    prices = [r.get("price") for r in results]
     assert "WPR5479LB" in part_nums
+    assert all(price is not None for price in prices)

--- a/test_rockauto.py
+++ b/test_rockauto.py
@@ -1,6 +1,6 @@
 import pytest
 import inspect
-from rockauto import rockauto_api, get_parts, get_closeout_deals, get_vehicle_info, search_parts
+from rockauto import rockauto_api, get_parts, get_closeout_deals, get_vehicle_info, search_parts, search_part_by_number
 
 def test_endpoints_exist():
     """Test that the required endpoints exist in the API"""
@@ -128,3 +128,11 @@ def test_search_endpoint_with_part_type():
         assert "part_type_code" in part
         assert "price" in part
         assert part["part_type_code"] == response["filters"]["part_type"]
+
+
+def test_part_number_search():
+    """Ensure searching by part number returns expected RockAuto part numbers"""
+    import asyncio
+    results = asyncio.run(search_part_by_number("4B0839461"))
+    part_nums = [r["part_number"] for r in results]
+    assert "WPR5479LB" in part_nums


### PR DESCRIPTION
## Summary
- add new `/part_number/{partnum}` endpoint to fetch cross-reference part numbers
- include async function `search_part_by_number`
- extend tests with `test_part_number_search`

## Testing
- `pip install mechanize`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef877c3dc832fa2f54bd126f590c8