### PR TITLE
Automatically craft search links

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ The API provides several endpoints to navigate RockAuto's parts catalog:
 * `/engines/{search_vehicle}` - Get engines for a specific make, year, and model
 * `/categories/{search_vehicle}` - Get part categories for a specific vehicle
 
+Many endpoints accept a `search_link` query parameter. If omitted, the API will attempt to construct this value automatically from the other parameters. You may also provide the `link` returned by the previous endpoint.
+
 #### Get Models for a Year
 ```
 GET /models/{search_vehicle}?search_make=Toyota&search_year=2015&search_link={link}


### PR DESCRIPTION
## Summary
- add `craft_search_link` helper to build RockAuto catalog URLs
- make search_link parameters optional and auto-populate when missing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f86364810832f838105d681f55562